### PR TITLE
fix: Base view detection and file extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 main.js
 .DS_Store
 data.json
+test/

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,14 +62,13 @@ export default class BaseCombinePlugin extends Plugin {
 
 		try {
 			// Get files from Base view by querying internal links
-			// @ts-ignore
 			const linkElements =
-				activeView.containerEl.querySelectorAll("a.internal-link");
+				activeView.containerEl.querySelectorAll("span.internal-link");
 
 			// Extract and filter hrefs using pure function
 			const links = Array.from(linkElements).map((element) => {
-				const link = element as HTMLAnchorElement;
-				return { href: link.getAttribute("href") };
+				const link = element as HTMLSpanElement;
+				return { href: link.getAttribute("data-href") };
 			});
 			const filteredHrefs = extractFilteredHrefs(links);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,7 +60,7 @@ export default class BaseCombinePlugin extends Plugin {
 			return null;
 		}
 
-		const results: Map<string, unknown> | undefined =
+		const results: Map<unknown, unknown> | undefined =
 			// @ts-ignore - controller.results is not in the public API
 			activeView.controller?.results;
 
@@ -70,11 +70,14 @@ export default class BaseCombinePlugin extends Plugin {
 		}
 
 		const files: TFile[] = [];
-		for (const path of results.keys()) {
-			if (!shouldIncludeFile(path)) {
+		for (const key of results.keys()) {
+			if (typeof key !== "string") {
 				continue;
 			}
-			const file = this.app.vault.getAbstractFileByPath(path);
+			if (!shouldIncludeFile(key)) {
+				continue;
+			}
+			const file = this.app.vault.getAbstractFileByPath(key);
 			if (file instanceof TFile) {
 				files.push(file);
 			}

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,16 +71,13 @@ export default class BaseCombinePlugin extends Plugin {
 
 		const files: TFile[] = [];
 		for (const key of results.keys()) {
-			if (typeof key !== "string") {
+			if (!(key instanceof TFile)) {
 				continue;
 			}
-			if (!shouldIncludeFile(key)) {
+			if (!shouldIncludeFile(key.path)) {
 				continue;
 			}
-			const file = this.app.vault.getAbstractFileByPath(key);
-			if (file instanceof TFile) {
-				files.push(file);
-			}
+			files.push(key);
 		}
 
 		if (files.length === 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, TFile, Notice, ItemView } from "obsidian";
+import { Plugin, TFile, Notice } from "obsidian";
 import {
 	combineFileContents,
 	generateTimestamp,
@@ -47,14 +47,14 @@ export default class BaseCombinePlugin extends Plugin {
 	}
 
 	getBaseFiles(): TFile[] | null {
-		const activeView = this.app.workspace.getActiveViewOfType(ItemView as any);
+		// @ts-ignore - activeLeaf is not in the public API
+		const activeView = this.app.workspace.activeLeaf?.view;
 
 		if (!activeView) {
 			new Notice("No active view found");
 			return null;
 		}
 
-		// @ts-ignore
 		if (activeView.getViewType() !== "bases") {
 			new Notice("Current view is not a Base. Please open a Base view first.");
 			return null;


### PR DESCRIPTION
## Changes

- Use `activeLeaf.view` instead of `getActiveViewOfType(ItemView)` for Base view detection (ItemView doesn't match Base views)
- Replace DOM scraping (`a.internal-link`) with `controller.results` Map from the Base view's internal API
- The results Map keys are TFile objects, not strings — use `instanceof TFile` to filter directly

## Testing

Tested manually in a test vault with:
- Multiple markdown files
- Folders containing files
- .base and .canvas files (correctly excluded)